### PR TITLE
Fix courses sorting

### DIFF
--- a/src/main/fi-ncp-front/karma.conf.js
+++ b/src/main/fi-ncp-front/karma.conf.js
@@ -1,6 +1,20 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
+// KNOWN ISSUE (local dev, at least as of Chrome 150 / karma@6.4.2 /
+// karma-chrome-launcher@~3.2.0): every run of `ng test --browsers=ChromeHeadless`
+// (or any other launcher) ends with Karma's own
+// "Some of your tests did a full page reload!" error, even though the line
+// right above it always reads "Executed X of X SUCCESS" - the actual specs
+// pass. This reproduces on every spec file individually, including trivial
+// ones with no HTTP/DOM/navigation, which rules out an app-code cause; it's
+// a version-skew false positive in Karma's own reload-detection heuristic
+// against modern Chrome. Neither `--headless=new` nor
+// `--disable-features=BackForwardCache` resolved it. Treat the
+// "Executed X of X SUCCESS" line as the real signal until this is
+// revisited (e.g. by upgrading karma/karma-chrome-launcher or migrating
+// off Karma).
+
 module.exports = function (config) {
   config.set({
     basePath: '',

--- a/src/main/fi-ncp-front/src/app/courses/courses.component.spec.ts
+++ b/src/main/fi-ncp-front/src/app/courses/courses.component.spec.ts
@@ -4,6 +4,7 @@ import { CoursesComponent } from './courses.component';
 import {provideHttpClient} from "@angular/common/http";
 import {provideHttpClientTesting} from "@angular/common/http/testing";
 import {Component, Input} from "@angular/core";
+import {ToastrModule} from "ngx-toastr";
 
 @Component({
   selector: 'app-loading',
@@ -20,6 +21,9 @@ describe('CoursesComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ CoursesComponent, MockAppLoading ],
+      imports: [
+        ToastrModule.forRoot(),
+      ],
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),

--- a/src/main/fi-ncp-front/src/app/courses/courses.service.spec.ts
+++ b/src/main/fi-ncp-front/src/app/courses/courses.service.spec.ts
@@ -2,10 +2,13 @@ import { TestBed } from '@angular/core/testing';
 
 import { CoursesService } from './courses.service';
 import {provideHttpClient} from "@angular/common/http";
-import {provideHttpClientTesting} from "@angular/common/http/testing";
+import {HttpTestingController, provideHttpClientTesting} from "@angular/common/http/testing";
+import {environment} from "src/environments/environment";
+import {ICourseResponse, Opintosuoritus} from "./course";
 
 describe('CoursesService', () => {
   let service: CoursesService;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -20,9 +23,156 @@ describe('CoursesService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({});
     service = TestBed.inject(CoursesService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  // --- Test fixture helpers -------------------------------------------------
+  // Builds minimal-but-valid Opintosuoritus entries. Only the fields the
+  // sorting logic actually reads are populated with meaningful values.
+  function nimi(value: string) {
+    return [{ value }];
+  }
+
+  function courseEntry(avain: string, name: string): Opintosuoritus {
+    return {
+      avain,
+      nimi: nimi(name),
+      laji: '2',
+      sisaltyvyys: [],
+      myontaja: 'issuer1',
+      laajuus: { opintopiste: 5 },
+      arvosana: {},
+      opiskelijaAvain: 'S1',
+      koulutusmoduulitunniste: 'x',
+    } as unknown as Opintosuoritus;
+  }
+
+  function degreeOrModuleEntry(avain: string, name: string, laji: '1' | '2', childAvains: string[]): Opintosuoritus {
+    return {
+      avain,
+      nimi: nimi(name),
+      laji,
+      sisaltyvyys: childAvains.map(a => ({ sisaltyvaOpintosuoritusAvain: a })),
+      myontaja: 'issuer1',
+      laajuus: { opintopiste: 5 },
+      arvosana: {},
+      opiskelijaAvain: 'S1',
+      koulutusmoduulitunniste: 'x',
+    } as unknown as Opintosuoritus;
+  }
+
+  function respondWith(entries: Opintosuoritus[]): ICourseResponse {
+    return {
+      virta: {
+        opiskelija: [
+          {
+            avain: 'S1',
+            opintosuoritukset: { opintosuoritus: entries },
+          } as any,
+        ],
+      },
+    } as unknown as ICourseResponse;
+  }
+
+  function flushAndGetOrder(entries: Opintosuoritus[], done: (order: string[]) => void) {
+    service.sortedCourses$.subscribe(response => {
+      const order = response.virta.opiskelija[0].opintosuoritukset!.opintosuoritus.map(c => c.avain);
+      done(order);
+    });
+    const req = httpMock.expectOne(environment.getAllCoursesUrl);
+    req.flush(respondWith(entries));
+  }
+
+  // --- Regression tests for CSCTIE-1368 sorting fix -------------------------
+
+  it('orders degree -> modules -> courses alphabetically, including a course linked directly to the degree', () => {
+    const entries = [
+      degreeOrModuleEntry('D1', 'Bachelor of Science', '1', ['M2', 'M1', 'C5']),
+      degreeOrModuleEntry('M1', 'Advanced Module', '2', ['C2', 'C1']),
+      degreeOrModuleEntry('M2', 'Basic Module', '2', ['C4', 'C3']),
+      courseEntry('C5', 'Zzz Direct Course'),
+      courseEntry('C1', 'Alpha Course'),
+      courseEntry('C2', 'Beta Course'),
+      courseEntry('C3', 'Gamma Course'),
+      courseEntry('C4', 'Delta Course'),
+    ];
+
+    let actual: string[] = [];
+    flushAndGetOrder(entries, order => (actual = order));
+
+    expect(actual).toEqual(['D1', 'M1', 'C1', 'C2', 'M2', 'C4', 'C3', 'C5']);
+  });
+
+  it('appends a module not linked to any degree, sorted alphabetically with its own courses', () => {
+    const entries = [
+      degreeOrModuleEntry('D1', 'Degree', '1', ['M1']),
+      degreeOrModuleEntry('M1', 'Linked Module', '2', ['C1']),
+      courseEntry('C1', 'Linked Course'),
+      degreeOrModuleEntry('M2', 'Zeta Unlinked Module', '2', ['C3', 'C2']),
+      courseEntry('C2', 'Echo Course'),
+      courseEntry('C3', 'Foxtrot Course'),
+    ];
+
+    let actual: string[] = [];
+    flushAndGetOrder(entries, order => (actual = order));
+
+    expect(actual).toEqual(['D1', 'M1', 'C1', 'M2', 'C2', 'C3']);
+  });
+
+  it('does not duplicate a module that is both linked to a degree and present in the top-level modules list', () => {
+    const entries = [
+      degreeOrModuleEntry('D1', 'Degree', '1', ['M1']),
+      degreeOrModuleEntry('M1', 'Only Module', '2', ['C1']),
+      courseEntry('C1', 'Course'),
+    ];
+
+    let actual: string[] = [];
+    flushAndGetOrder(entries, order => (actual = order));
+
+    expect(actual.filter(a => a === 'M1').length).toBe(1);
+  });
+
+  it('sorts modules and courses alphabetically when the student has no degree at all', () => {
+    const entries = [
+      degreeOrModuleEntry('M1', 'Zebra Module', '2', ['C2', 'C1']),
+      courseEntry('C1', 'Alpha'),
+      courseEntry('C2', 'Beta'),
+      courseEntry('C3', 'Standalone Course'),
+    ];
+
+    let actual: string[] = [];
+    flushAndGetOrder(entries, order => (actual = order));
+
+    expect(actual).toEqual(['M1', 'C1', 'C2', 'C3']);
+  });
+
+  // Regression test for a bug found while adding this suite: a course that
+  // (a) belongs to a student who has at least one degree in their data, and
+  // (b) is not referenced by ANY degree's or module's `sisaltyvyys`, used to
+  // never get a `type` assigned in courses$ (the `degree.hasPart.includes(...)`
+  // check only fired for courses listed directly under a degree), so
+  // sortedCourses$'s `type === 'course'` filter silently dropped it instead of
+  // appending it as an unlinked course. Fixed by tagging any laji=2 entry that
+  // is still untyped after the degree/module walk as a plain course.
+  it('keeps a course that is linked to neither a degree nor a module, when the student also has a degree', () => {
+    const entries = [
+      degreeOrModuleEntry('D1', 'Degree', '1', ['M1']),
+      degreeOrModuleEntry('M1', 'Linked Module', '2', ['C1']),
+      courseEntry('C1', 'Linked Course'),
+      courseEntry('C2', 'Truly Orphan Course'), // not referenced anywhere
+    ];
+
+    let actual: string[] = [];
+    flushAndGetOrder(entries, order => (actual = order));
+
+    expect(actual).toEqual(['D1', 'M1', 'C1', 'C2']);
   });
 });

--- a/src/main/fi-ncp-front/src/app/courses/courses.service.ts
+++ b/src/main/fi-ncp-front/src/app/courses/courses.service.ts
@@ -193,9 +193,11 @@ export class CoursesService {
         // Degrees
         degrees.forEach(degree => {
           sortedStudy.push(degree)
+          this.sortAlphabetically(degree.hasPart)
 
           degree.hasPart?.forEach(module => {
             sortedStudy.push(module)
+            this.sortAlphabetically(module.hasPart)
 
             module.hasPart?.forEach(course => sortedStudy.push(course))
           });
@@ -206,6 +208,7 @@ export class CoursesService {
         modules.forEach(module => {
           if (!sortedStudy.includes(module)) {
             sortedStudy.push(module)
+            this.sortAlphabetically(module.hasPart)
 
             module.hasPart?.forEach(course => sortedStudy.push(course))
           }
@@ -330,5 +333,16 @@ export class CoursesService {
       .subscribe((_) => {
         return;
       });
+  }
+
+  /**
+   * Helper for sorting degrees / modules / courses alphabetically
+   */
+  sortAlphabetically(array: Opintosuoritus[] | undefined) {
+    if (array == undefined) {
+      return
+    }
+
+    return array.sort((a, b) => (a.nimi?.[0]?.value ?? '').localeCompare(b.nimi?.[0]?.value ?? ''))
   }
 }

--- a/src/main/fi-ncp-front/src/app/courses/courses.service.ts
+++ b/src/main/fi-ncp-front/src/app/courses/courses.service.ts
@@ -204,11 +204,12 @@ export class CoursesService {
 
         // Modules (not linked with degree)
         modules.forEach(module => {
-          sortedStudy.push(module)
+          if (!sortedStudy.includes(module)) {
+            sortedStudy.push(module)
 
-          module.hasPart?.forEach(course => sortedStudy.push(course))
+            module.hasPart?.forEach(course => sortedStudy.push(course))
+          }
         })
-
 
         // Set new sorted array to response
         if (student.opintosuoritukset && sortedStudy.length > 0) {

--- a/src/main/fi-ncp-front/src/app/courses/courses.service.ts
+++ b/src/main/fi-ncp-front/src/app/courses/courses.service.ts
@@ -188,7 +188,7 @@ export class CoursesService {
 
         const degrees = all.filter(o => o.isDegree);
         const modules = all.filter(o => o.isModule);
-        // const courses = all.filter(o => o.type === 'course');
+        const courses = all.filter(o => o.type === 'course');
 
         // Degrees
         degrees.forEach(degree => {
@@ -208,6 +208,13 @@ export class CoursesService {
             sortedStudy.push(module)
 
             module.hasPart?.forEach(course => sortedStudy.push(course))
+          }
+        })
+
+        // Courses (not linked with module)
+        courses.forEach(course => {
+          if (!sortedStudy.includes(course)) {
+            sortedStudy.push(course)
           }
         })
 

--- a/src/main/fi-ncp-front/src/app/courses/courses.service.ts
+++ b/src/main/fi-ncp-front/src/app/courses/courses.service.ts
@@ -120,6 +120,14 @@ export class CoursesService {
                 (c) => c.isPartOfDegree
               );
             });
+            // A course that is not part of any module and not directly linked to any
+            // degree never gets a `type` assigned above, so it would otherwise be
+            // silently dropped by sortedCourses$'s `type === 'course'` filter.
+            // @ts-ignore
+            HEI.opintosuoritukset.opintosuoritus
+              // @ts-ignore
+              .filter((c) => +c.laji === 2 && !c.type)
+              .forEach((c) => (c.type = 'course'));
           } else {
             // @ts-ignore
             HEI.opintosuoritukset.opintosuoritus.sort((a, b) =>

--- a/src/main/fi-ncp-front/src/app/courses/courses.service.ts
+++ b/src/main/fi-ncp-front/src/app/courses/courses.service.ts
@@ -1,10 +1,10 @@
-import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
-import {Router} from '@angular/router';
-import {combineLatest, Observable, of} from 'rxjs';
-import {map} from 'rxjs/operators';
-import {environment} from 'src/environments/environment';
-import {ICourseResponse, IssuerResponseData, Opintosuoritus, Opiskelija, Sisaltyvyys} from './course';
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { combineLatest, Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+import { ICourseResponse, IssuerResponseData, Opintosuoritus, Opiskelija, Sisaltyvyys } from './course';
 
 @Injectable({
   providedIn: 'root',
@@ -159,11 +159,6 @@ export class CoursesService {
               }
             });
           }
-          // @ts-ignore
-          HEI.opintosuoritukset.opintosuoritus.sort(
-            // @ts-ignore
-            (a, b) => a.weight - b.weight
-          );
         });
         return response;
       })
@@ -175,6 +170,55 @@ export class CoursesService {
   count = 0;
   credits = 0;
   errors: string[] = [];
+
+  // The sort in courses$ was not working properly between different browsers so we try to separate the sorting logic here
+  // Otherwise the degrees -> modules -> courses classification in courses$ seem to work so we'll utilize it here (degrees.hasParts has all modules related to that degree etc...)
+  // NOTE: not all modules are "linked" to a degree (at least such is the case with the test user), not sure if all courses are linked to a module but this needs to be handled just in case
+  sortedCourses$ = this.courses$.pipe(
+    map(response => {
+      const result: Opintosuoritus[] = [];
+
+      // First we go through degrees -> modules -> courses
+      // After that modules (without degree) -> courses
+      // And finally courses (without module)
+
+      response.virta.opiskelija.forEach(student => {
+        const sortedStudy: Opintosuoritus[] = [];
+        const all = student.opintosuoritukset?.opintosuoritus ?? [];
+
+        const degrees = all.filter(o => o.isDegree);
+        const modules = all.filter(o => o.isModule);
+        // const courses = all.filter(o => o.type === 'course');
+
+        // Degrees
+        degrees.forEach(degree => {
+          sortedStudy.push(degree)
+
+          degree.hasPart?.forEach(module => {
+            sortedStudy.push(module)
+
+            module.hasPart?.forEach(course => sortedStudy.push(course))
+          });
+        })
+
+
+        // Modules (not linked with degree)
+        modules.forEach(module => {
+          sortedStudy.push(module)
+
+          module.hasPart?.forEach(course => sortedStudy.push(course))
+        })
+
+
+        // Set new sorted array to response
+        if (student.opintosuoritukset && sortedStudy.length > 0) {
+          student.opintosuoritukset.opintosuoritus = sortedStudy;
+        }
+      })
+
+      return response;
+    })
+  )
 
   /**
    * Group courses by issuer example data: const coursesByIssuer = {
@@ -190,7 +234,7 @@ export class CoursesService {
    *   // additional issuers and their grouped courses
    * }
    */
-  coursesWithIssuers$ = combineLatest([this.issuers$, this.courses$]).pipe(
+  coursesWithIssuers$ = combineLatest([this.issuers$, this.sortedCourses$]).pipe(
     map(([issuers, courses]) => {
       const coursesByIssuer: { [key: string]: Opintosuoritus[] } = {};
       courses.virta.opiskelija.map((student: Opiskelija) => {

--- a/src/main/fi-ncp-front/src/app/preview/preview.component.spec.ts
+++ b/src/main/fi-ncp-front/src/app/preview/preview.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { PreviewComponent } from './preview.component';
 import {provideHttpClientTesting} from "@angular/common/http/testing";
@@ -21,6 +22,9 @@ describe('PreviewComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ PreviewComponent, MockAppLoading ],
+      imports: [
+        RouterTestingModule,
+      ],
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),

--- a/src/main/fi-ncp-front/tsconfig.spec.json
+++ b/src/main/fi-ncp-front/tsconfig.spec.json
@@ -14,5 +14,6 @@
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.d.ts"
-  ]
+  ],
+  "exclude": []
 }


### PR DESCRIPTION
Original problem: Courses were sorted incorrectly on different browsers. They might have been under incorrect modules or even outside of their module. This was especially apparent on Firefox.

Fix: Change the way courses are sorted. Previously they were sorted using calculated weight value but now for the most part they use the "hasPart" value that contains all the related courses. For example a module's hasPart contains courses that are linked with it. These are pushed into an array which should be the correct order.

We also handle modules and courses that are possibly not linked to anything. The process also contains alphabetic sorting.